### PR TITLE
完善 swoole_timer_tick 注释

### DIFF
--- a/src/Functionals.php
+++ b/src/Functionals.php
@@ -479,7 +479,7 @@ function swoole_timer_clear($timer_id)
 /**
  * 添加TICK定时器
  * @param      $ms
- * @param      $callback  function($timmerID, $params){}
+ * @param      mixed $callback function($timmerID, $params){}
  * @param null $params
  * @return int
  */


### PR DESCRIPTION
如果不给 swoole_timer_tick 第二个参数 $callback 指定返回类型，在 swoole_timer_tick(1000, [$this, 'onTick']) 这种用法时，PHPStorm 会提示出错